### PR TITLE
vold: Allow reset after shutdown

### DIFF
--- a/VolumeBase.cpp
+++ b/VolumeBase.cpp
@@ -161,7 +161,9 @@ std::shared_ptr<VolumeBase> VolumeBase::findVolume(const std::string& id) {
 }
 
 status_t VolumeBase::create() {
-    CHECK(!mCreated);
+    if (mCreated) {
+        return BAD_VALUE;
+    }
 
     mCreated = true;
     notifyEvent(ResponseCode::VolumeCreated,
@@ -176,7 +178,9 @@ status_t VolumeBase::doCreate() {
 }
 
 status_t VolumeBase::destroy() {
-    CHECK(mCreated);
+    if (!mCreated) {
+        return NO_INIT;
+    }
 
     if (mState == State::kMounted) {
         unmount();


### PR DESCRIPTION
 * If we shutdown all volumes (during crypto), vold throws up an
   assert at us when reset() is called due to destroying an
   already destroyed volume. This is actually fine, just return
   an error instead of crashing.

Change-Id: I51f8561da83e27de8e80d74f3a600fb0139d3035